### PR TITLE
Fix minimist's incorrect handling of unknown flags

### DIFF
--- a/__test__/index.test.ts
+++ b/__test__/index.test.ts
@@ -20,3 +20,30 @@ test('exclude', () => {
     }
   })
 })
+
+test('unknown', () => {
+  const options = {
+    boolean: ['foo'],
+    unknown: jest.fn()
+  }
+  expect(minimost(['--foo', 'bar'], options)).toEqual({
+    input: ['bar'],
+    flags: {
+      foo: true,
+      '--': []
+    }
+  })
+  expect(options.unknown).not.toHaveBeenCalled()
+
+  options.unknown.mockClear()
+  minimost(['--foo', '--bar'], options)
+  expect(options.unknown).toHaveBeenCalledWith('--bar')
+
+  options.unknown.mockClear()
+  minimost(['--foo', '-b'], options)
+  expect(options.unknown).toHaveBeenCalledWith('-b')
+
+  options.unknown.mockClear()
+  minimost(['--foo', '-'], options)
+  expect(options.unknown).not.toHaveBeenCalled()
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,10 +7,17 @@ const kebab2camel = (input: string) => {
 }
 
 export default function (argv: string[], options?: Opts) {
-  const parsed = minimist(argv, Object.assign({
-    '--': true
-  }, options))
+  options = Object.assign({ '--': true }, options)
 
+  const unknown = options.unknown
+  if (typeof unknown === 'function') {
+    options.unknown = function (input) {
+      if (input === '-' || !input.startsWith('-')) return
+      return unknown.call(this, input)
+    }
+  }
+
+  const parsed = minimist(argv, options)
   const input = parsed._
   delete parsed._
 


### PR DESCRIPTION
Do not treat commands or arguments as flags, handle stdin symbol (`-`).
This solves long known and extremely problematic https://github.com/substack/minimist/issues/86 plus it fits well in minimost's vision of being better minimist 😃 